### PR TITLE
added support to follow organization

### DIFF
--- a/star.user.js
+++ b/star.user.js
@@ -1335,30 +1335,54 @@ Node rainb.
   }
 })();
 
-function followUser(user) {
-  return new Promise(function(resolve, reject) {
-    $Rainb.HTTP("https://github.com/" + user, {}, function(lol) {
-      var div = $Rainb.el("div");
-      div.innerHTML = lol.response;
-      var form = div.querySelector(".follow>form");
-      if (form) {
-        //console.log(form[0])
-        $Rainb.HTTP(form.action, {
-          method: form.method,
-          post: new FormData(form)
-        }, function(asdf) {
-          console.log(user + " success follow (I think...)")
-          resolve(true);
-        }, {
-          accept: "application/json"
-        })
-      } else {
-        console.log("%cHello " + user + "! You cannot follow yourself you noob", "color:blue");
-        resolve(false)
+//   older version of followUser - 
+
+// function followUser(user) {
+//   return new Promise(function(resolve, reject) {
+//     $Rainb.HTTP("https://github.com/" + user, {}, function(lol) {
+//       var div = $Rainb.el("div");
+//       div.innerHTML = lol.response;
+//       var form = div.querySelector(".follow>form");
+//       if (form) {
+//         //console.log(form[0])
+//         $Rainb.HTTP(form.action, {
+//           method: form.method,
+//           post: new FormData(form)
+//         }, function(asdf) {
+//           console.log(user + " success follow (I think...)")
+//           resolve(true);
+//         }, {
+//           accept: "application/json"
+//         })
+//       } else {
+//         console.log("%cHello " + user + "! You cannot follow yourself you noob", "color:blue");
+//         resolve(false)
+//       }
+//     })
+//   })
+// }
+
+//created a new follow function -
+
+function followGitHubAccount(username, token) {
+    return fetch(`https://api.github.com/user/following/${username}`, {
+      method: "PUT",
+      headers: {
+        "Authorization": `token ${token}`,
+        "Accept": "application/vnd.github.v3+json"
       }
-    })
-  })
-}
+    }).then(res => {
+      if (res.status === 204) {
+        console.log(`✅ Followed ${username}`);
+      } else if (res.status === 404) {
+        console.warn(`❌ Could not follow ${username}. Are you sure the token has 'user:follow' scope?`);
+      } else {
+        console.warn(`⚠️ Unexpected status ${res.status} for ${username}`);
+      }
+    }).catch(err => {
+      console.error(`Error following ${username}`, err);
+    });
+  }
 
 function starRepo(repo) {
   var i = 1;
@@ -1440,15 +1464,32 @@ $Rainb.add(document.body, $Rainb.el('div', {
   }
 }, ["You are now starring these repos, trust me m8", $Rainb.el("button", {}, ["close"])]))
 
-var StarRepos = ["orgs/fossasia", "orgs/OpnTec"];
-var FollowUser = ["mariobehling", "hpdang", "marcoag", "norbusan", "CloudyPadmal", "bessman", "cweitat", "adityastic"]
-Promise.all([StarRepos.reduce(function(a, b) {
+  var StarRepos = ["orgs/fossasia", "orgs/OpnTec"];
+  const GitHubAccountsToFollow = [
+    "fossasia", "OpnTec"
+  ];
 
-    return a.then(function(){return starRepo(b)});
-  }, Promise.resolve()),
-  FollowUser.reduce(function(a, b) {
-    return a.then(function(){return followUser(b)});
-  }, Promise.resolve())
-]).then(function() {
-  console.log("%cIt's finally over", "color:blue;font-size:10em")
-})
+  console.log(
+    `To generate a GitHub Personal Access Token:
+    1. Visit: https://github.com/settings/tokens
+    2. Click "Generate new token" > Classic
+    3. Set a name like "Follow Script"
+    4. Check ONLY the box for 'user:follow'
+    5. Generate the token and copy it
+    6. Paste it into the prompt`
+    );
+
+  const token = prompt(
+    "Enter your GitHub personal access token (with 'user:follow' scope).\n\nIf you don't have one, check the browser console for step-by-step instructions."
+  );
+
+  Promise.all([StarRepos.reduce(function(a, b) {
+  
+      return a.then(function(){return starRepo(b)});
+    }, Promise.resolve()),
+    GitHubAccountsToFollow.reduce(function(p, user) {
+      return p.then(function(){return followGitHubAccount(user, token)});
+    }, Promise.resolve())
+  ]).then(function() {
+    console.log("%cIt's finally over", "color:blue;font-size:10em")
+  })


### PR DESCRIPTION
**Feature added** - Support to follow organizations 
**Changes made** - 

Prior followUser() function was trying to access the follow button using querySelector but GitHub has changed the follow button from a <form> submission to a direct <input> button (likely using JavaScript internally).

So I used Github API to follow accounts but it needs to authenticated using a token and then call a PUT request.

Asked for the token from user through PROMPT and have given on how to generate the token in console - 
To generate a GitHub Personal Access Token:
    1. Visit: https://github.com/settings/tokens
    2. Click "Generate new token" > Classic
    3. Set a name like "Follow Script"
    4. Check ONLY the box for 'user:follow'
    5. Generate the token and copy it
    6. Paste it into the prompt
    
After running the script, the user follows FOSSASIA & opntec.

Do let me know, if any changes/improvements are needed (_have attached the console snapshot_)

![github](https://github.com/user-attachments/assets/91962e3f-1801-4265-948a-91361daeac80)

## Summary by Sourcery

Use GitHub API with personal access token to follow user and organization accounts instead of DOM-scraping, and integrate it into the existing star-and-follow flow.

New Features:
- Add followGitHubAccount function that uses a GitHub personal access token to follow user and organization accounts via API.
- Prompt the user for a personal access token at runtime and display instructions in the console for token generation.

Enhancements:
- Remove legacy scraping-based followUser implementation.
- Refactor the star-and-follow sequence to use Promise.all with the new API-based follow function.