### PR TITLE
Limit StarMe onboarding to FOSSASIA repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Starring is fun and following open source projects even more so.
 
 Star Me is a small browser based script that helps developers quickly connect with FOSSASIA projects on GitHub.
-By running the script in your browser console while logged into GitHub, you can automatically star repositories and stay up to date with project activity.
+By running the script in your browser console while logged into GitHub, you can automatically star FOSSASIA repositories so GitHub can surface relevant project activity in your home feed.
 
 This tool is primarily intended for onboarding, workshops, and community engagement. No GitHub token or API access is required.
 
@@ -12,7 +12,7 @@ This tool is primarily intended for onboarding, workshops, and community engagem
 * Automatically stars FOSSASIA repositories on GitHub
 * Runs entirely in your browser while you are logged in
 * Does not require any installation, extensions, or authentication tokens
-* Helps you discover projects and receive updates more easily
+* Helps you discover FOSSASIA projects and relevant activity
 
 ## Requirements
 
@@ -69,8 +69,8 @@ Then press <kbd>Enter</kbd>.
 The script will run for a few minutes depending on the number of repositories.
 
 When finished, it prints
-“Finally Over ;-)”
-in blue color.
+“FOSSASIA repositories are now starred.”
+in blue.
 
 Please allow the script to run until completion.
 
@@ -80,7 +80,7 @@ Once finished, the repositories will appear in your starred list on GitHub.
 
 You can now
 * Explore projects that match your interests
-* Receive updates and notifications
+* See relevant FOSSASIA activity in your GitHub home feed
 * Start contributing to FOSSASIA open source projects
 
 ## Safety note

--- a/star.user.js
+++ b/star.user.js
@@ -1335,31 +1335,6 @@ Node rainb.
   }
 })();
 
-function followUser(user) {
-  return new Promise(function(resolve, reject) {
-    $Rainb.HTTP("https://github.com/" + user, {}, function(lol) {
-      var div = $Rainb.el("div");
-      div.innerHTML = lol.response;
-      var form = div.querySelector(".follow>form");
-      if (form) {
-        //console.log(form[0])
-        $Rainb.HTTP(form.action, {
-          method: form.method,
-          post: new FormData(form)
-        }, function(asdf) {
-          console.log(user + " success follow (I think...)")
-          resolve(true);
-        }, {
-          accept: "application/json"
-        })
-      } else {
-        console.log("%cHello " + user + "! You cannot follow yourself you noob", "color:blue");
-        resolve(false)
-      }
-    })
-  })
-}
-
 function starRepo(repo) {
   var i = 1;
   var x = Promise.resolve([])
@@ -1438,17 +1413,14 @@ $Rainb.add(document.body, $Rainb.el('div', {
     backgroundColor: "rebeccapurple",
     padding: "2em 10%"
   }
-}, ["You are now starring these repos, trust me m8", $Rainb.el("button", {}, ["close"])]))
+}, ["You are now starring FOSSASIA repositories.", $Rainb.el("button", {}, ["close"])]))
 
-var StarRepos = ["orgs/fossasia", "orgs/OpnTec"];
-var FollowUser = ["mariobehling", "hpdang", "marcoag", "norbusan", "CloudyPadmal", "bessman", "cweitat", "adityastic"]
-Promise.all([StarRepos.reduce(function(a, b) {
+var StarRepos = ["orgs/fossasia"];
 
-    return a.then(function(){return starRepo(b)});
-  }, Promise.resolve()),
-  FollowUser.reduce(function(a, b) {
-    return a.then(function(){return followUser(b)});
-  }, Promise.resolve())
-]).then(function() {
-  console.log("%cIt's finally over", "color:blue;font-size:10em")
-})
+StarRepos.reduce(function(sequence, repo) {
+  return sequence.then(function() {
+    return starRepo(repo);
+  });
+}, Promise.resolve()).then(function() {
+  console.log("%cFOSSASIA repositories are now starred.", "color:blue;font-size:4em");
+});


### PR DESCRIPTION
## Summary

- remove automatic following of individual GitHub accounts
- remove automatic starring of OpnTec repositories
- limit StarMe to starring repositories in the FOSSASIA organization
- align the script messages and README with the actual behavior
- describe relevant project activity as appearing in the GitHub home feed rather than promising notifications

## Validation

- verified that the updated script parses successfully
- verified that it contains no OpnTec organization or individual-account follow actions
- verified that its only explicit network endpoint is the GitHub API used to enumerate organization repositories

## Summary by Sourcery

Limit StarMe onboarding to FOSSASIA repositories and remove unrelated account-following and repository-starring actions.

Enhancements:
- Restrict StarMe onboarding to starring repositories in the FOSSASIA organization.
- Remove automatic GitHub account following and OpnTec repository starring.
- Align the browser script’s status messages and README guidance with its FOSSASIA-only behavior and GitHub home-feed activity.

Documentation:
- Update README wording to accurately describe FOSSASIA repository starring and GitHub home-feed activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Updated guidance and completion messages to refer specifically to FOSSASIA repositories and related activity.
  - The script now stars only FOSSASIA repositories.
  - Repository processing occurs sequentially for more predictable completion.
  - Removed user-following behavior and processing for OpnTec.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->